### PR TITLE
feat: add flags to modify command

### DIFF
--- a/.github/workflows/version_verify.yaml
+++ b/.github/workflows/version_verify.yaml
@@ -54,8 +54,7 @@ jobs:
   
         - name: 🧬 Generate new asset graph
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'publish')) }}
-          run: |
-            dart run build_runner build --delete-conflicting-outputs
+          run: dart run build_runner build --delete-conflicting-outputs
             
         - name: 🆕 Commit changes
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'publish')) }}

--- a/.github/workflows/version_verify.yaml
+++ b/.github/workflows/version_verify.yaml
@@ -39,51 +39,34 @@ jobs:
         
         - name: ➕ Bump major version
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'major release')) }}
-          run: |
-            mag modify -b --major
-            git commit -am "chore(deps): bump major version"
-            git push
-          env:
-            GIT_AUTHOR_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_AUTHOR_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
-            GIT_COMMITTER_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_COMMITTER_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
+          run: mag modify -b --major
+          
         
         - name: ➕ Bump minor version
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'minor release')) }}
-          run: |
-            mag modify -b --minor
-            git commit -am "chore(deps): bump minor version"
-            git push
-          env:
-            GIT_AUTHOR_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_AUTHOR_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
-            GIT_COMMITTER_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_COMMITTER_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
+          run: mag modify -b --minor
+            
           
         - name: ➕ Bump patch version
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'patch release')) }}
-          run: |
-            mag modify -b --patch
-            git commit -am "chore(deps): bump patch version"
-            git push
-          env:
-            GIT_AUTHOR_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_AUTHOR_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
-            GIT_COMMITTER_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_COMMITTER_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
+          run: mag modify -b --patch
+            
   
         - name: 🧬 Generate new asset graph
           if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'publish')) }}
           run: |
             dart run build_runner build --delete-conflicting-outputs
-            git commit -am "chore(build): generated new asset graph"
+            
+        - name: 🆕 Commit changes
+          if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'publish')) }}
+          run: |
+            git commit -am "chore: bump package version"
             git push
           env:
-            GIT_AUTHOR_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_AUTHOR_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
-            GIT_COMMITTER_NAME: ${{ steps.corn-fig-git.outputs.name }}
-            GIT_COMMITTER_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
+              GIT_AUTHOR_NAME: ${{ steps.corn-fig-git.outputs.name }}
+              GIT_AUTHOR_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
+              GIT_COMMITTER_NAME: ${{ steps.corn-fig-git.outputs.name }}
+              GIT_COMMITTER_EMAIL: ${{ steps.corn-fig-git.outputs.email }}
 
     verify-version:
         needs: update-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.5.0
+**Features**
+* added new `set-version` option to both commands. `yaml-version` will be deprecated in future versions.
+* added new `preset` flag to `modify` command.
+* added `keep-pre` & `keep-build` flags to `modify` command.
+* added `set-build` & `set-prerelease` options to `modify` command.
+
+Check README & example for more info.
+
+**Improvements**
+* updated README & examples to be more clear and concise.
+* added new tests for new flags & options.
+
 # 0.4.0
 **Features**
 * added new `flags` and `options` to `change` command

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ A command-line tool for changing/modifying the version specified in Flutter/Dart
 
 ## Table of Contents
 - [Getting Started](#getting-started)
-- [Overview](#overview)
-    - [Executable Name](#executable-name)
-    - [Available Commands](#commands)
-    - [Available Flags and Options](#flags-and-options)
-- [Default](#default)
+- [Executable Name](#executable-name)
+- [Available Commands](#commands)
 - [Basic Usage](#basic-usage)
+- [Available Flags](#flags)
+- [Available Options](#options)
+- [Flag & Options in Command](#flags--options-in-commands)
+- [Default](#default)
+- [Known Caveats](#known-caveats)
 
 ## Getting Started
 
@@ -25,7 +27,7 @@ dart pub global activate magical_version_bump
 
 ## Overview
 
-`magical_version_bump` is a simple command-line tool. Use it to update your yaml files in your project ci/cd. Check out our github action in the repository.
+`magical_version_bump` is a simple command-line tool. Use it to update your yaml files in your project ci or even locally. Check out our github action in the repository.
 
 ![Update meme](https://storage.googleapis.com/magical_kenya_bucket/7lqtb5.jpg)
 
@@ -42,43 +44,101 @@ dart pub global activate magical_version_bump
 | `modify` | This command explicitly modifies a specific [SemVer](https://semver.org/) version number in the version specified in your pubspec.yaml.|
 | `change` | This command overwrites specified node in pubspec.yaml file.|
 
-## Flags and Options
+## Basic Usage
 
-The `modify` command dictates that `action` flags precede the `target` flags. Available flags include: 
+Usage of the CLI is easy and straight-forward.
+
+```sh
+# Check package version
+$ mag -v
+
+# Print help menu
+$ mag -h
+
+# Print command help menu
+$ mag modify -h
+
+$ mag change -h
+
+```
+
+Check example tab/folder for more.
+
+## Flags
+
+When using the `modify` command, flags are split into 2 categories:
+- `action` - specifies whether to `bump` or `dump` the version by 1.
+- `target` - specifies which specific [SemVer](https://semver.org/) version number you are targeting.
 
 | Flags            | Shorthand abbreviation | Type        | Function |
 |------------------|------------------------|-------------|----------|
-| `--bump`         | `-b`                   | `action`    | Tells CLI to increment by 1 |
-| `--dump`         | `-d`                   | `action`    | Tells CLI to decrement by 1 |
-| `--major`        | -                      | `target`    | Tells CLI to target the major version number |
-| `--minor`        | -                      | `target`    | Tells CLI to target the minor version number |
-| `--patch`        | -                      | `target`    | Tells CLI to target the patch version number |
-| `--build-number` | -                      | `target`    | Tells CLI to target the build-number |
-| `--with-path`    | -                      | `target`    | Tells CLI to request the path from you and not check the current directory |
-| `--set-path`     |                        | `N/A`       | Sets path to pubspec.yaml file |
+| `--bump`         |
+| `--dump`         | `-d`                   | `action`    | Tells CLI tool to decrement by 1 |
+| `--major`        | -                      | `target`    | Tells CLI tool to target the major version number |
+| `--minor`        | -                      | `target`    | Tells CLI tool to target the minor version number |
+| `--patch`        | -                      | `target`    | Tells CLI tool to target the patch version number |
+| `--build-number` | -                      | `target`    | Tells CLI tool to target the build-number |
+| `--with-path`    | -                      | `target`    | Tells CLI tool to request the path from you and not check the current directory |
+| `--preset`       | -                      | N/A         | Explicitly indicates that the tool should preset any version, prerelease and build info before bumping up/down the version |
+| `--keep-pre`     | -                      | N/A         | Explicitly indicates that the tool should keep any existing prerelease version found |
+| `--keep-build`   | -                      | N/A         | Explicitly indicates that the tool should keep any existing build metadata found |
 
-NOTE: `set-path` takes precedence over `with-path`. Tool will remove the `with-path` or any duplicates for this found.
 
-The `change` command takes in options which you can pass in values to. It also includes one flag.
+NOTE: Flags do not take in any value. They are passed in as is.
 
-| Flags           | Shorthand abbreviation | Function |
-|-----------------|------------------------|----------|
-| `--with-path`   | -                      | Tells CLI to request the path from you and not check the current directory |
-| `--keep-pre`    | -                      | Explicitly indicates that the tool should keep any existing prerelease version found |
-| `--keep-build`  | -                      | Explicitly indicates that the tool should keep any existing build metadata found |
+## Options
 
-| Options           | Shorthand abbreviation | Function                        |
-|-------------------|------------------------|---------------------------------|
-| `--set-path`      | -                      | Sets path to pubspec.yaml file |
-| `--set-prerelease`  | -                      | Change the prerelease version in the version specified in your pubspec.yaml file |
-| `--set-build`     | -                      | Change build metadata appended to the version in your pubspec.yaml file |
-| `--name`          | -                      | Change the name in pubspec.yaml |
-| `--description`   | -                      | Change the description of your project in pubspec.yaml |
-| `--yaml-version`  | -                      | Option to completely change the version in pubspec.yaml |
-| `--homepage`      | -                      | Change the homepage url in pubspec.yaml |
-| `--repository`    | -                      | Change the repository url for project in pubspec.yaml |
-| `--issue_tracker` | -                      | Change the url pointing to an issue tracker in pubspec.yaml |
-| `--documentation` | -                      | Change the url pointing to your project's documentation in pubspec.yaml |
+These, on the other hand, take in values you explicitly specify. When using options:
+- Pass in a value using `=` sign. Like so: `--option=value`
+- If the value has any spaces, enclose it with speech marks/double quotes. Like so : `--option="my value with space"`
+
+| Options             | Function                        |
+|---------------------|---------------------------------|
+| `--set-path`        | Sets path to pubspec.yaml file |
+| `--set-prerelease`  | Change the prerelease version in the version specified in your pubspec.yaml file |
+| `--set-build`       | Change build metadata appended to the version in your pubspec.yaml file |
+| `--set-version`     | Change the version in your pubspec.yaml file |
+
+Other useful options available include:
+
+| Options           | Function                        |
+| `--name`          | Change the name in pubspec.yaml |
+| `--description`   | Change the description of your project in pubspec.yaml |
+| `--yaml-version`  | Option to completely change the version in pubspec.yaml |
+| `--homepage`      | Change the homepage url in pubspec.yaml |
+| `--repository`    | Change the repository url for project in pubspec.yaml |
+| `--issue_tracker` | Change the url pointing to an issue tracker in pubspec.yaml |
+| `--documentation` | Change the url pointing to your project's documentation in pubspec.yaml |
+
+NOTE: `yaml-version` will be deprecated in favour of `set-version` in future release after `v0.5.0`.
+
+## Flags & Options in Commands
+
+Some flags/options can be used in both command while others cannot. Check table below.
+
+| Flag/Option           | `modify` command  | `change` command  |
+| --------------------- | ----------------- | ----------------- |
+| `--bump`              |         ✅        |         ❌        |   
+| `--dump`              |         ✅        |         ❌        |
+| `--major`             |         ✅        |         ❌        |
+| `--minor`             |         ✅        |         ❌        |
+| `--patch`             |         ✅        |         ❌        |
+| `--build-number`      |         ✅        |         ❌        |
+| `--with-path`         |         ✅        |         ✅        |
+| `--preset`            |         ✅        |         ❌        |
+| `--keep-pre`          |         ✅        |         ✅        |
+| `--keep-build`        |         ✅        |         ✅        |
+| `--set-path`          |         ✅        |         ✅        |
+| `--set-prerelease`    |         ✅        |         ✅        |
+| `--set-build`         |         ✅        |         ✅        |
+| `--set-version`       |         ✅        |         ✅        |
+| `--name`              |         ❌        |         ✅        |
+| `--description`       |         ❌        |         ✅        |
+| `--yaml-version`      |         ❌        |         ✅        |
+| `--homepage`          |         ❌        |         ✅        |
+| `--repository`        |         ❌        |         ✅        |
+| `--issue_tracker`     |         ❌        |         ✅        |
+| `--documentation`     |         ❌        |         ✅        |
 
 ## Default
 * The tool will always check the current folder for the pubspec.yaml file. Add a `--with-path` flag to nudge the CLI to request the path from you.
@@ -88,10 +148,10 @@ mag modify -b --major --with-path # Requests path
 
 mag modify -b --major --set-path=path-to-fil # Checks directory specified
 
-
+# If set-path is used, with-path will be removed
 ```
 
-* The tool will always do a relative versioning strategy. The collective version will be bumped up/down based on the position of the version passed in.
+* The tool will always do a relative versioning strategy. The collective version will be bumped up/down based on the position of the version passed in. This is the default versioning recommended by `Dart` & [SemVer](https://semver.org/).
 
 ```sh
 mag modify --bump --major # Bumps version 1.1.1 to 2.0.0
@@ -124,25 +184,37 @@ mag modify --bump --major --minor --patch --absolute
 
 ```
 
-## Basic Usage
-
-Usage of the CLI is easy and straight-forward.
+* If you pass in `set-version` when using `modify` command, the version will be updated before any other action is performed on the version.
 
 ```sh
-# Check package version
-$ mag -v
+# Initial version was 2.3.4
 
-# Print help menu
-$ mag -h
+mag modify --set-version=8.8.8 --bump major
 
-# Print command help menu
-$ mag modify -h
-
-$ mag change -h
+# Version 2.3.4 updated to 8.8.8 first.
+# Version 8.8.8 then bumped to 9.0.0
 
 ```
 
-Check example tab/folder for more.
+* Using `set-version` also removes the build metadata and any prerelease info in the version. Pass in `--keep-build` or `--keep-pre` to keep desired data
+```sh
+# Initial version was 2.3.4-alpha+22
+
+mag modify --set-version=8.8.8
+
+# Final version will be 8.8.8
+
+mag modify --set-version=8.8.8 --keep-build --keep-pre
+
+# Final version will be 8.8.8-alpha+22
+
+```
+
+## Known Caveats
+* Cannot bump prerelease or custom build numbers. To work around this, consider using `set-prerelease` or `set-build`.
+
+If you notice any more issue, please do raise them. Hope you like the package!
+
 
 <!--[coverage_badge]: coverage_badge.svg-->
 [license_badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/example/README.md
+++ b/example/README.md
@@ -21,95 +21,163 @@ my pubspec.yaml's major/minor/patch/build-number version - TARGET
 
 ```
 
-## Basic Usage
+## Modify Command
+- This command is versatile and can be used to change or modify the version in your pubspec.yaml.
+- You need to specify an `action` and a `target` when bumping your version. The `action` flag must be specified first. Either `--bump` or `-b`.
 
-By default, the command will update any `pubspec.yaml` file in the current directory and bumps up each version relative to its position.
-
-* Bump up any version by 1. You have to use the `modify` command paired with `--bump` or `-b` flags and at least 1 target.
-
-```sh
-# Bump up any version
-
-$ mag modify --bump --major  -  version 1.1.1+1 becomes 2.0.0+1
-
-$ mag modify -b --major  -  version 1.1.1+1 becomes 2.0.0+1  # same as above but relatively shorter
-
-$ mag modify -b --minor  -  version 1.1.1+1 becomes 1.2.0+1
-
-$ mag modify -b --patch  -  version 1.1.1+1 becomes 1.1.2+1
-
-$ mag modify -b --build-number  -  version 1.0.0+1 becomes 1.0.0+2
-
-```
-
-* Bump down any version by 1. You have to use the `modify` command paired with `--dump` or `-d` flags and at least 1 target. Consider using the `change` command to revert your version to a lower value than the current one. 
+### Basic Usage
+- By default, the tool uses the versioning strategy specified [here](https://semver.org/). 
 
 ```sh
-# Bump down any version
+mag modify --bump --major # Version 1.1.3 becomes 2.0.0
 
-$ mag modify --dump --major  -  version 2.1.1+1 becomes 1.0.0+1
+mag modify --bump --minor # Version 1.1.3 becomes 1.2.0
 
-$ mag modify -d --major  -  version 2.1.1+1 becomes 1.0.0+1  # same as above but shorter
+mag modify --bump --patch # Version 1.1.3 becomes 1.1.4
 
-$ mag modify -d --minor  -  version 1.1.1+1 becomes 1.0.0+1
-
-$ mag modify -d --patch  -  version 1.1.1+1 becomes 1.1.0+1
-
-$ mag modify -d --build-number  -  version 1.0.0+2 becomes 1.0.0+1
+mag modify --bump --build-number # Version 1.1.3+2 becomes 1.1.3+3
 
 ```
 
-* Change a specific node in your yaml file. You have to use the `change` command and provide a node and its new value to change it. Flutter/Dart yaml node supported currently are : `name`,  `description`,  `version`,  `homepage`,  `repository`,  `issue_tracker`,  `documentation`. You can also change the prerelease info using `set-prerelease` and build metadata using `set-build`
+- If no build number is passed in, the tool will append 1 and bump it.
 
+```sh
 
-``` sh
-# Change current version to an entirely different version. 
-
-$ mag change --name="Hello World Project" # name is change to Hello World Project
-
-# This applies to all nodes listed above.
+mag modify --bump --build-number # Version 1.1.3 becomes 1.1.3+2
 
 ```
 
-## Dynamic Usage
+- If you want each version to be bumped independently, pass in the `--absolute` flag.
 
-* You can combine various targets in the `modify` command.
+```sh
+mag modify --bump --major --absolute # Version 1.1.3 becomes 2.1.3
 
-``` sh
-# Bump up major and minor versions using absolute versioning
+mag modify --bump --minor --absolute # Version 1.1.3 becomes 1.2.3
 
-$ mag -b --major --minor --absolute  -  version 1.0.0 becomes 2.1.0
+mag modify --bump --patch --absolute # Version 1.1.3 becomes 1.1.4
 
-# Bump down minor, patch and build-number versions using absolute versioning
-
-$ mag -d --minor --patch --build-number --absolute  -  version 2.2.1+18 becomes 2.1.0+17
-
-# Bump down the major and build-number versions using absolute versioning
-
-$ mag -d --build-number --major --absolute  -  version 2.0.1+14 becomes 1.0.1+13
+mag modify --bump --build-number --absolute # Version 1.1.3+2 becomes 1.1.3+3
 
 ```
 
-Notice how in the last example the sequence of the targets doesn't matter. As long as the flag is a recognized target, the version will be modified accordingly.
+### Advanced Usage
 
-* You can nudge the CLI and tell it not to check the current directory for the pubspec.yaml file with the `--with-path` flag. The CLI will prompt you for the path. You need to provide the directory + yaml file.
+- You can chain multiple targets to be bumped. However, the default strategy will get the target with the highest weight. Passing in the `--absolute` flag will nudge the tool to target each independently.
 
-```md
-path specified will be `directory-with-yaml/myFile.yaml`
+```sh
+
+# You can also use the shorthand -b instead of --bump
+mag modify -b major minor patch # Version 1.8.9 becomes 2.0.0 
+
+# major version has the highest weight
+# major -> minor -> patch -> build-number
+
+mag modify -b major minor patch --absolute # Version 1.8.9 becomes 2.9.10
+
+# Each version is bumped independently.
+
 ```
 
-``` sh
-# Bump up with specified path
 
-$ mag modify -b --major --with-path  -  requests path and version 1.0.0 becomes 2.0.0
+- In case your yaml file is in a different directory, use the `with-path` flag or `set-path` option. You have to include the yaml file in the directory provided.
+
+```sh
+
+mag modify -b major --with-path # Will request path from you in an interactive way in the console
+
+mag modify -b major --set-path="my-path/pubspec.yaml" # Automatically checks directory specified
 
 ```
 
-* Alternatively you can provide a path directly with `set-path`
 
-``` sh
-# Bump up with specified path
+- By default, `set-version` sets a new version before bumping to desired version
 
-$ mag modify -b --major --set-path=path-to-file  -  reads from path and version 1.0.0 becomes 2.0.0
+```sh
+
+# Initial version 1.8.9
+
+mag modify --set-version=2.8.4 -b major 
+
+# Version changed to 2.8.4 first
+# Version then bumped to 3.0.0
+
+# It also works with absolute
+
+mag modify --set-version=2.8.4 -b major --absolute
+
+# Version changed to 2.8.4 first
+# Version then bumped to 3.8.4
+
+```
+
+
+- `set-version` removes any build & prerelease info from version being replaced. To keep previous build or prerelease info, pass in the `--keep-build` and `--keep-pre` flags respectively. You don't have to use them together. These flags can be used separately.
+
+```sh
+
+# Initial version 1.8.9-alpha+22
+
+mag modify --set-version=2.8.4 -b major --keep-build 
+# Version changed to 2.8.4 first
+# Version then bumped to 3.0.0+22. Old build metadata is appended & prerelease info removed
+
+
+mag modify --set-version=2.8.4 -b major --keep-pre
+# Version changed to 2.8.4 first
+# Version then bumped to 3.0.0-alpha. Prerelease info is appended & old build metadata is removed
+
+
+mag modify --set-version=2.8.4 -b major --keep-build --keep-pre
+# Version changed to 2.8.4 first
+# Version then bumped to 3.0.0-alpha+22. Both the old build metadata & prerelease info are appended
+
+```
+
+
+- You can also preset the build and prerelease info if you need to perform any action on the build metadata. Use the `preset` flag to nudget tool to preset them before bumping anything.
+
+```sh
+
+# Initial version 1.8.9
+
+mag modify --preset --set-version=2.8.4 --set-prerelease="dev.2" --set-build=10 --bump --major --build-number
+# Version changed to 2.8.4-dev.2+10
+# Version then bumped to 3.0.0+11
+# Prerelease info is removed since we are bumping up to a major version
+
+
+```
+
+
+- You can also preset only the version first then append the prerelease and metadata info. Just remove/do not pass in the `preset` flag.
+
+```sh
+
+# Initial version 1.8.9
+
+mag modify --set-version=2.8.4 --set-prerelease="dev.2" --set-build=10 --bump --major
+# Version changed to 2.8.4
+# Version then bumped to 3.0.0
+# Prerelease info & build metadata appended after
+# Version becomes 3.0.0-dev.2+10
+
+```
+
+## Change Command
+This command is straight-forward and modifies nodes in your yaml file. The nodes currently supported include:
+- name - `--name` 
+- description - `--description`
+- version - `--yaml-version`, `--set-version`
+- homepage url - `--homepage` 
+- repository url - `--repository` 
+- issue-tracker url - `--issue_tracker`
+- documentation url - `--documentation`
+
+* Specify an accepted option and pass in a value
+
+```sh
+
+mag change --name="My new name"
+# Your project name changes to "My new name"
 
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -134,7 +134,7 @@ mag modify --set-version=2.8.4 -b major --keep-build --keep-pre
 ```
 
 
-- You can also preset the build and prerelease info if you need to perform any action on the build metadata. Use the `preset` flag to nudget tool to preset them before bumping anything.
+- You can also preset the build and prerelease info if you need to perform any action on the build metadata. Use the `preset` flag to nudge tool to preset them before bumping anything.
 
 ```sh
 

--- a/lib/src/commands/change_command.dart
+++ b/lib/src/commands/change_command.dart
@@ -43,6 +43,10 @@ class ChangeNodesCommand extends Command<int> {
             '''Change build metadata appended to the version in your pubspec.yaml file''',
       )
       ..addOption(
+        'set-version',
+        help: '''Option to completely change the version in pubspec.yaml''',
+      )
+      ..addOption(
         'name',
         help: '''Change the name in pubspec.yaml''',
       )

--- a/lib/src/commands/modify_command.dart
+++ b/lib/src/commands/modify_command.dart
@@ -60,6 +60,12 @@ class ModifyVersionCommand extends Command<int> {
         negatable: false,
       )
       ..addFlag(
+        'preset',
+        help:
+            '''Explicitly indicates that the tool should preset any version, prerelease and build info before bumping up/down the version''',
+        negatable: false,
+      )
+      ..addFlag(
         'keep-pre',
         help:
             '''Explicitly indicates that the tool should keep any existing prerelease version found''',

--- a/lib/src/commands/modify_command.dart
+++ b/lib/src/commands/modify_command.dart
@@ -58,6 +58,32 @@ class ModifyVersionCommand extends Command<int> {
         help:
             '''Tells CLI to bump each version independent of the other versions present''',
         negatable: false,
+      )
+      ..addFlag(
+        'keep-pre',
+        help:
+            '''Explicitly indicates that the tool should keep any existing prerelease version found''',
+        negatable: false,
+      )
+      ..addFlag(
+        'keep-build',
+        help:
+            '''Explicitly indicates that the tool should keep any existing build metadata found''',
+        negatable: false,
+      )
+      ..addOption(
+        'set-prerelease',
+        help:
+            '''Change the prerelease version in the version specified in your pubspec.yaml file''',
+      )
+      ..addOption(
+        'set-build',
+        help:
+            '''Change build metadata appended to the version in your pubspec.yaml file''',
+      )
+      ..addOption(
+        'set-version',
+        help: '''Option to completely change the version in pubspec.yaml''',
       );
   }
 

--- a/lib/src/utils/extensions/version_extension.dart
+++ b/lib/src/utils/extensions/version_extension.dart
@@ -101,8 +101,10 @@ extension VersionExtension on Version {
       major,
       minor,
       patch,
-      pre: updatedPre ?? (keepPre ? preRelease.join('.') : null),
-      build: updatedBuild ?? (keepBuild ? build.join('.') : null),
+      pre: updatedPre ??
+          (keepPre || preRelease.isNotEmpty ? preRelease.join('.') : null),
+      build: updatedBuild ??
+          (keepBuild || build.isNotEmpty ? build.join('.') : null),
     ).toString();
   }
 

--- a/lib/src/utils/extensions/version_extension.dart
+++ b/lib/src/utils/extensions/version_extension.dart
@@ -97,6 +97,13 @@ extension VersionExtension on Version {
     String? updatedPre,
     String? updatedBuild,
   }) {
+    if ((keepPre && preRelease.isEmpty) || (keepBuild && build.isEmpty)) {
+      throw MagicalException(
+        violation:
+            '''You cannot change to new version and keep old prelease and build info''',
+      );
+    }
+
     return Version(
       major,
       minor,

--- a/lib/src/utils/extensions/version_extension.dart
+++ b/lib/src/utils/extensions/version_extension.dart
@@ -108,10 +108,8 @@ extension VersionExtension on Version {
       major,
       minor,
       patch,
-      pre: updatedPre ??
-          (keepPre || preRelease.isNotEmpty ? preRelease.join('.') : null),
-      build: updatedBuild ??
-          (keepBuild || build.isNotEmpty ? build.join('.') : null),
+      pre: updatedPre ?? (keepPre ? preRelease.join('.') : null),
+      build: updatedBuild ?? (keepBuild ? build.join('.') : null),
     ).toString();
   }
 

--- a/lib/src/utils/extensions/version_extension.dart
+++ b/lib/src/utils/extensions/version_extension.dart
@@ -100,7 +100,7 @@ extension VersionExtension on Version {
     if ((keepPre && preRelease.isEmpty) || (keepBuild && build.isEmpty)) {
       throw MagicalException(
         violation:
-            '''You cannot change to new version and keep old prelease and build info''',
+            '''You cannot change to new version and keep old prerelease and build info''',
       );
     }
 

--- a/lib/src/utils/handlers/command_handlers.dart
+++ b/lib/src/utils/handlers/command_handlers.dart
@@ -1,3 +1,2 @@
 export 'handle_change_command.dart';
-export 'handle_generate_command.dart';
 export 'handle_modify_command.dart';

--- a/lib/src/utils/handlers/handle_change_command.dart
+++ b/lib/src/utils/handlers/handle_change_command.dart
@@ -58,19 +58,20 @@ class HandleChangeCommand
       logger.warn('Version flag detected. Must verify version is valid');
 
       if (validatedArgs.args.contains('yaml-version')) {
-        logger..warn(
-          """Consider using 'set-version'. 'yaml-version' will be deprecated soon""",
-        )
-        ..warn(
-          """'set-version' will overwrite 'yaml-version' if both are used""",
-        );
+        logger
+          ..warn(
+            """Consider using 'set-version'. 'yaml-version' will be deprecated soon""",
+          )
+          ..warn(
+            """'set-version' will overwrite 'yaml-version' if both are used""",
+          );
       }
 
       // Check version that user want to change to or the current version
       version = await validateVersion(
         logger: logger,
-        version: preppedArgs['yaml-version'] ??
-            argsWithoutSetters.version ??
+        version: argsWithoutSetters.version ??
+            preppedArgs['yaml-version'] ??
             fileData.yamlMap['version'] as String?,
       );
     }
@@ -105,7 +106,9 @@ class HandleChangeCommand
     if (argsWithoutSetters.build != null ||
         argsWithoutSetters.prerelease != null ||
         argsWithoutSetters.version != null) {
-      final updatedVersion = Version.parse(version).setPreAndBuild(
+      final updatedVersion = Version.parse(
+        argsWithoutSetters.version ?? version,
+      ).setPreAndBuild(
         keepPre: argsWithoutSetters.keepPre,
         keepBuild: argsWithoutSetters.keepBuild,
         updatedPre: argsWithoutSetters.prerelease,

--- a/lib/src/utils/handlers/handle_change_command.dart
+++ b/lib/src/utils/handlers/handle_change_command.dart
@@ -57,6 +57,15 @@ class HandleChangeCommand
         argsWithoutSetters.version != null) {
       logger.warn('Version flag detected. Must verify version is valid');
 
+      if (validatedArgs.args.contains('yaml-version')) {
+        logger..warn(
+          """Consider using 'set-version'. 'yaml-version' will be deprecated soon""",
+        )
+        ..warn(
+          """'set-version' will overwrite 'yaml-version' if both are used""",
+        );
+      }
+
       // Check version that user want to change to or the current version
       version = await validateVersion(
         logger: logger,

--- a/lib/src/utils/handlers/handle_change_command.dart
+++ b/lib/src/utils/handlers/handle_change_command.dart
@@ -52,8 +52,8 @@ class HandleChangeCommand
 
     // If user wants version change, check if valid
     if (validatedArgs.args.contains('yaml-version') ||
-        validatedArgs.args.contains('set-prerelease') ||
-        validatedArgs.args.contains('set-build') ||
+        argsWithoutSetters.prerelease != null ||
+        argsWithoutSetters.build != null ||
         argsWithoutSetters.version != null) {
       logger.warn('Version flag detected. Must verify version is valid');
 

--- a/lib/src/utils/handlers/handle_change_command.dart
+++ b/lib/src/utils/handlers/handle_change_command.dart
@@ -94,7 +94,8 @@ class HandleChangeCommand
 
     // Update any 'set-prerelease' or 'set-build' options after 'yaml-version'
     if (argsWithoutSetters.build != null ||
-        argsWithoutSetters.prerelease != null) {
+        argsWithoutSetters.prerelease != null ||
+        argsWithoutSetters.version != null) {
       final updatedVersion = Version.parse(version).setPreAndBuild(
         keepPre: argsWithoutSetters.keepPre,
         keepBuild: argsWithoutSetters.keepBuild,

--- a/lib/src/utils/handlers/handle_change_command.dart
+++ b/lib/src/utils/handlers/handle_change_command.dart
@@ -24,11 +24,13 @@ class HandleChangeCommand
     // Normalize args & check validity
     final normalizedArgs = normalizeArgs(args);
 
-    final preppedArgs = getArgAndValues(normalizedArgs.args);
+    final argsWithoutSetters = checkForSetters(normalizedArgs);
+
+    final preppedArgs = getArgAndValues(argsWithoutSetters.args);
 
     final validatedArgs = await validateArgs(
       preppedArgs.keys.toList(),
-      userSetPath: normalizedArgs.hasPath,
+      userSetPath: argsWithoutSetters.path != null,
       logger: logger,
     );
 
@@ -43,7 +45,7 @@ class HandleChangeCommand
     final fileData = await readFile(
       requestPath: validatedArgs.args.contains('with-path'),
       logger: logger,
-      setPath: normalizedArgs.setPath,
+      setPath: argsWithoutSetters.path,
     );
 
     var version = '';
@@ -51,13 +53,15 @@ class HandleChangeCommand
     // If user wants version change, check if valid
     if (validatedArgs.args.contains('yaml-version') ||
         validatedArgs.args.contains('set-prerelease') ||
-        validatedArgs.args.contains('set-build')) {
+        validatedArgs.args.contains('set-build') ||
+        argsWithoutSetters.version != null) {
       logger.warn('Version flag detected. Must verify version is valid');
 
       // Check version that user want to change to or the current version
       version = await validateVersion(
         logger: logger,
         version: preppedArgs['yaml-version'] ??
+            argsWithoutSetters.version ??
             fileData.yamlMap['version'] as String?,
       );
     }
@@ -80,10 +84,7 @@ class HandleChangeCommand
       (element) => element.key != 'with-path',
     );
 
-    // Check if user wanted to change prerelease or build
-    final checkedNodes = checkNodes(entries);
-
-    for (final node in checkedNodes.nodes) {
+    for (final node in entries) {
       editedFile = await editYamlFile(
         editedFile,
         node.key == 'yaml-version' ? 'version' : node.key,
@@ -92,12 +93,13 @@ class HandleChangeCommand
     }
 
     // Update any 'set-prerelease' or 'set-build' options after 'yaml-version'
-    if (checkedNodes.build != null || checkedNodes.pre != null) {
+    if (argsWithoutSetters.build != null ||
+        argsWithoutSetters.prerelease != null) {
       final updatedVersion = Version.parse(version).setPreAndBuild(
-        keepPre: checkedNodes.keepPre,
-        keepBuild: checkedNodes.keepBuild,
-        updatedPre: checkedNodes.pre,
-        updatedBuild: checkedNodes.build,
+        keepPre: argsWithoutSetters.keepPre,
+        keepBuild: argsWithoutSetters.keepBuild,
+        updatedPre: argsWithoutSetters.prerelease,
+        updatedBuild: argsWithoutSetters.build,
       );
 
       editedFile = await editYamlFile(editedFile, 'version', updatedVersion);
@@ -110,56 +112,5 @@ class HandleChangeCommand
 
     /// Show success
     logger.success('Updated your yaml file!');
-  }
-
-  /// Check whether prerelease or build are being modified
-  ({
-    ChangeableNodes nodes,
-    bool keepPre,
-    bool keepBuild,
-    String? pre,
-    String? build,
-  }) checkNodes(
-    ChangeableNodes nodes,
-  ) {
-    var keepPre = false;
-    var keepBuild = false;
-    String? pre;
-    String? build;
-
-    final modifiedNodes = nodes.fold(
-      <MapEntry<String, String>>[],
-      (previousValue, element) {
-        switch (element.key) {
-          case 'keep-pre':
-            keepPre = true;
-            break;
-
-          case 'keep-build':
-            keepBuild = true;
-            break;
-
-          case 'set-build':
-            build = element.value.isEmpty ? null : element.value;
-            break;
-
-          case 'set-prerelease':
-            pre = element.value.isEmpty ? null : element.value;
-            break;
-
-          default:
-            previousValue.add(element);
-        }
-        return previousValue;
-      },
-    );
-
-    return (
-      nodes: modifiedNodes,
-      keepPre: keepPre,
-      keepBuild: keepBuild,
-      pre: pre,
-      build: build,
-    );
   }
 }

--- a/lib/src/utils/handlers/handle_generate_command.dart
+++ b/lib/src/utils/handlers/handle_generate_command.dart
@@ -1,1 +1,0 @@
-class HandleGenerateCommand {}

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -53,7 +53,7 @@ class HandleModifyCommand
 
     // Preset any values before validation. This assumes you want keep your old
     // build number and prelease info
-    if (argsWithNoSetters.preset) {
+    if (argsWithNoSetters.preset || argsWithNoSetters.presetOnlyVersion) {
       // Parse old version
       Version? oldVersion;
 
@@ -86,7 +86,8 @@ class HandleModifyCommand
     currentVersion = await validateVersion(
       logger: logger,
       // Use isModify only when preset is false
-      isModify: !argsWithNoSetters.preset,
+      isModify:
+          !argsWithNoSetters.preset && !argsWithNoSetters.presetOnlyVersion,
       yamlMap: fileData.yamlMap,
       version: currentVersion,
     );
@@ -109,7 +110,7 @@ class HandleModifyCommand
 
     /// If preset is false, but user passed in prerelease & build info.
     /// Update it.
-    if (!argsWithNoSetters.preset &&
+    if ((!argsWithNoSetters.preset || argsWithNoSetters.presetOnlyVersion) &&
         (argsWithNoSetters.prerelease != null ||
             argsWithNoSetters.build != null)) {
       modifiedVersion = Version.parse(modifiedVersion).setPreAndBuild(

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -23,10 +23,12 @@ class HandleModifyCommand
     // Normalize args & check validity
     final normalizedArgs = normalizeArgs(args);
 
+    final argsWithNoSetters = checkForSetters(normalizedArgs);
+
     final validated = await validateArgs(
-      normalizedArgs.args,
+      argsWithNoSetters.args,
       isModify: true,
-      userSetPath: normalizedArgs.hasPath,
+      userSetPath: argsWithNoSetters.path != null,
       logger: logger,
     );
 
@@ -43,7 +45,7 @@ class HandleModifyCommand
     final fileData = await readFile(
       requestPath: preppedArgs.requestPath,
       logger: logger,
-      setPath: normalizedArgs.setPath,
+      setPath: argsWithNoSetters.path,
     );
 
     // Validate version and get correct version

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -137,12 +137,8 @@ class HandleModifyCommand
     );
 
     /// Show success
-    logger
-      ..success(
-        """Version ${preppedArgs.action == 'b' || preppedArgs.action == 'bump' ? 'bumped up' : 'bumped down'} from $currentVersion to $modifiedVersion""",
-      )
-      ..write(
-        'v$modifiedVersion',
-      );
+    logger.success(
+      """Version ${preppedArgs.action == 'b' || preppedArgs.action == 'bump' ? 'bumped up' : 'bumped down'} from $currentVersion to $modifiedVersion""",
+    );
   }
 }

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -137,8 +137,12 @@ class HandleModifyCommand
     );
 
     /// Show success
-    logger.success(
-      """Version ${preppedArgs.action == 'b' || preppedArgs.action == 'bump' ? 'bumped up' : 'bumped down'} from $currentVersion to $modifiedVersion""",
-    );
+    logger
+      ..success(
+        """Version ${preppedArgs.action == 'b' || preppedArgs.action == 'bump' ? 'bumped up' : 'bumped down'} from $currentVersion to $modifiedVersion""",
+      )
+      ..write(
+        'v$modifiedVersion',
+      );
   }
 }

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -52,7 +52,7 @@ class HandleModifyCommand
     var currentVersion = '';
 
     // Preset any values before validation. This assumes you want keep your old
-    // build number and prelease info
+    // build number and prerelease info
     if (argsWithNoSetters.preset || argsWithNoSetters.presetOnlyVersion) {
       // Parse old version
       Version? oldVersion;

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -108,8 +108,8 @@ class HandleModifyCommand
       strategy: preppedArgs.strategy,
     );
 
-    /// If preset is false, but user passed in prerelease & build info.
-    /// Update it.
+    // If preset is false, but user passed in prerelease & build info.
+    // Update it.
     if ((!argsWithNoSetters.preset || argsWithNoSetters.presetOnlyVersion) &&
         (argsWithNoSetters.prerelease != null ||
             argsWithNoSetters.build != null)) {

--- a/lib/src/utils/handlers/handle_modify_command.dart
+++ b/lib/src/utils/handlers/handle_modify_command.dart
@@ -1,8 +1,9 @@
 import 'package:magical_version_bump/src/utils/enums/enums.dart';
 import 'package:magical_version_bump/src/utils/exceptions/command_exceptions.dart';
-import 'package:magical_version_bump/src/utils/extensions/iterable_extension.dart';
+import 'package:magical_version_bump/src/utils/extensions/extensions.dart';
 import 'package:magical_version_bump/src/utils/mixins/command_mixins.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 class HandleModifyCommand
     with
@@ -48,11 +49,46 @@ class HandleModifyCommand
       setPath: argsWithNoSetters.path,
     );
 
+    var currentVersion = '';
+
+    // Preset any values before validation. This assumes you want keep your old
+    // build number and prelease info
+    if (argsWithNoSetters.preset) {
+      // Parse old version
+      Version? oldVersion;
+
+      if (fileData.yamlMap['version'] != null) {
+        oldVersion = Version.parse(fileData.yamlMap['version'].toString());
+      }
+
+      // Throw error if both 'set-version' and old version are null
+      if (argsWithNoSetters.version == null && oldVersion == null) {
+        throw MagicalException(
+          violation: 'At least one valid version is required.',
+        );
+      }
+
+      currentVersion = Version.parse(
+        argsWithNoSetters.version ?? oldVersion.toString(),
+      ).setPreAndBuild(
+        updatedPre: argsWithNoSetters.keepPre
+            ? (oldVersion!.preRelease.isEmpty
+                ? null
+                : oldVersion.preRelease.join('.'))
+            : argsWithNoSetters.prerelease,
+        updatedBuild: argsWithNoSetters.keepBuild
+            ? (oldVersion!.build.isEmpty ? null : oldVersion.build.join('.'))
+            : argsWithNoSetters.build,
+      );
+    }
+
     // Validate version and get correct version
-    final currentVersion = await validateVersion(
+    currentVersion = await validateVersion(
       logger: logger,
-      isModify: true,
+      // Use isModify only when preset is false
+      isModify: !argsWithNoSetters.preset,
       yamlMap: fileData.yamlMap,
+      version: currentVersion,
     );
 
     // Modify the version
@@ -62,7 +98,7 @@ class HandleModifyCommand
           : 'Bumping down version',
     );
 
-    final modifiedVersion = await dynamicBump(
+    var modifiedVersion = await dynamicBump(
       currentVersion,
       action: preppedArgs.action,
       versionTargets: preppedArgs.strategy == ModifyStrategy.absolute
@@ -70,6 +106,19 @@ class HandleModifyCommand
           : preppedArgs.versionTargets.getRelative(),
       strategy: preppedArgs.strategy,
     );
+
+    /// If preset is false, but user passed in prerelease & build info.
+    /// Update it.
+    if (!argsWithNoSetters.preset &&
+        (argsWithNoSetters.prerelease != null ||
+            argsWithNoSetters.build != null)) {
+      modifiedVersion = Version.parse(modifiedVersion).setPreAndBuild(
+        keepPre: argsWithNoSetters.keepPre,
+        keepBuild: argsWithNoSetters.keepBuild,
+        updatedPre: argsWithNoSetters.prerelease,
+        updatedBuild: argsWithNoSetters.build,
+      );
+    }
 
     final modifiedFile = await editYamlFile(
       fileData.file,

--- a/lib/src/utils/mixins/normalize_args_mixin.dart
+++ b/lib/src/utils/mixins/normalize_args_mixin.dart
@@ -11,7 +11,8 @@ mixin NormalizeArgs {
     'set-prerelease',
     'set-version',
     'keep-pre',
-    'keep-build'
+    'keep-build',
+    'preset'
   ];
 
   /// Normalize arguments. Remove '-' or '--' present.
@@ -44,6 +45,7 @@ mixin NormalizeArgs {
     String? prerelease,
     bool keepPre,
     bool keepBuild,
+    bool preset,
   }) checkForSetters(List<String> args) {
     final modifiableArgs = [...args]; // Modifiable list
 
@@ -54,6 +56,7 @@ mixin NormalizeArgs {
       'set-version': null,
       'keep-pre': false,
       'keep-build': false,
+      'preset': false,
     };
 
     for (final setter in setters) {
@@ -65,7 +68,9 @@ mixin NormalizeArgs {
         // Retain only elements without this value
         modifiableArgs.retainWhere((element) => !element.contains(setter));
 
-        if (setter == 'keep-pre' || setter == 'keep-build') {
+        if (setter == 'keep-pre' ||
+            setter == 'keep-build' ||
+            setter == 'preset') {
           modifiableMap.update(setter, (value) => true);
         } else {
           modifiableMap.update(
@@ -87,6 +92,9 @@ mixin NormalizeArgs {
       prerelease: modifiableMap['set-prerelease'],
       keepPre: modifiableMap['keep-pre'],
       keepBuild: modifiableMap['keep-build'],
+      // set-version defaults preset to true
+      preset: (modifiableMap['set-version'] != null) ||
+          modifiableMap['preset'] as bool
     );
   }
 

--- a/lib/src/utils/mixins/normalize_args_mixin.dart
+++ b/lib/src/utils/mixins/normalize_args_mixin.dart
@@ -85,6 +85,8 @@ mixin NormalizeArgs {
       }
     }
 
+    final preset = modifiableMap['preset'] as bool;
+
     return (
       args: modifiableArgs,
       path: modifiableMap['set-path'],
@@ -93,9 +95,9 @@ mixin NormalizeArgs {
       prerelease: modifiableMap['set-prerelease'],
       keepPre: modifiableMap['keep-pre'],
       keepBuild: modifiableMap['keep-build'],
-      preset: modifiableMap['preset'],
-      // set-version defaults presetVersion to true
-      presetOnlyVersion: modifiableMap['set-version'] != null
+      preset: preset,
+      // set-version defaults presetOnlyVersion to true if preset is not true
+      presetOnlyVersion: modifiableMap['set-version'] != null && !preset
     );
   }
 

--- a/lib/src/utils/mixins/normalize_args_mixin.dart
+++ b/lib/src/utils/mixins/normalize_args_mixin.dart
@@ -33,7 +33,7 @@ mixin NormalizeArgs {
   /// Check whether user set/used these flags
   /// 1. set-path
   /// 2. set-build
-  /// 3. set-prelease
+  /// 3. set-prerelease
   /// 4. set-version
   /// 5. keep-pre
   /// 6. keep-build

--- a/lib/src/utils/mixins/normalize_args_mixin.dart
+++ b/lib/src/utils/mixins/normalize_args_mixin.dart
@@ -46,6 +46,7 @@ mixin NormalizeArgs {
     bool keepPre,
     bool keepBuild,
     bool preset,
+    bool presetOnlyVersion,
   }) checkForSetters(List<String> args) {
     final modifiableArgs = [...args]; // Modifiable list
 
@@ -92,9 +93,9 @@ mixin NormalizeArgs {
       prerelease: modifiableMap['set-prerelease'],
       keepPre: modifiableMap['keep-pre'],
       keepBuild: modifiableMap['keep-build'],
-      // set-version defaults preset to true
-      preset: (modifiableMap['set-version'] != null) ||
-          modifiableMap['preset'] as bool
+      preset: modifiableMap['preset'],
+      // set-version defaults presetVersion to true
+      presetOnlyVersion: modifiableMap['set-version'] != null
     );
   }
 

--- a/lib/src/utils/mixins/normalize_args_mixin.dart
+++ b/lib/src/utils/mixins/normalize_args_mixin.dart
@@ -8,7 +8,7 @@ mixin NormalizeArgs {
   final setters = <String>[
     'set-path',
     'set-build',
-    'set-prelease',
+    'set-prerelease',
     'set-version',
     'keep-pre',
     'keep-build'
@@ -50,7 +50,7 @@ mixin NormalizeArgs {
     final modifiableMap = <String, dynamic>{
       'set-path': null,
       'set-build': null,
-      'set-prelease': null,
+      'set-prerelease': null,
       'set-version': null,
       'keep-pre': false,
       'keep-build': false,
@@ -84,7 +84,7 @@ mixin NormalizeArgs {
       path: modifiableMap['set-path'],
       version: modifiableMap['set-version'],
       build: modifiableMap['set-build'],
-      prerelease: modifiableMap['set-prelease'],
+      prerelease: modifiableMap['set-prerelease'],
       keepPre: modifiableMap['keep-pre'],
       keepBuild: modifiableMap['keep-build'],
     );

--- a/lib/src/utils/mixins/validate_args_mixin.dart
+++ b/lib/src/utils/mixins/validate_args_mixin.dart
@@ -47,16 +47,16 @@ mixin ValidatePreppedArgs {
     required Logger logger,
     bool isModify = false,
   }) async {
-    // Args must not be empty
-    if (args.isEmpty && isModify) {
-      return (
-        invalidReason: const InvalidReason(
-          'Missing arguments',
-          'No arguments found',
-        ),
-        args: <String>[],
-      );
-    }
+    // // Args must not be empty
+    // if (args.isEmpty && isModify) {
+    //   return (
+    //     invalidReason: const InvalidReason(
+    //       'Missing arguments',
+    //       'No arguments found',
+    //     ),
+    //     args: <String>[],
+    //   );
+    // }
 
     final modifiableArgs = [...args];
 
@@ -91,7 +91,7 @@ mixin ValidatePreppedArgs {
 
     // Check for correct order of flags as specified above on `actions` &
     // `targets` variables
-    if (isModify) {
+    if (isModify && args.isNotEmpty) {
       final standardsError = _checkFlags(modifiableArgs);
 
       if (standardsError.isNotEmpty) {

--- a/lib/src/utils/mixins/validate_args_mixin.dart
+++ b/lib/src/utils/mixins/validate_args_mixin.dart
@@ -48,7 +48,7 @@ mixin ValidatePreppedArgs {
     bool isModify = false,
   }) async {
     // Args must not be empty
-    if (args.isEmpty) {
+    if (args.isEmpty && isModify) {
       return (
         invalidReason: const InvalidReason(
           'Missing arguments',

--- a/test/src/commands/change_command_test.dart
+++ b/test/src/commands/change_command_test.dart
@@ -24,6 +24,7 @@ void main() {
   const docArg = '--documentation=https://url.to.documentation';
   const preleaseArg = '--set-prerelease=test';
   const buildArg = '--set-build=100';
+  const setVersionArg = '--set-version=8.8.8+8';
 
   setUp(() {
     logger = _MockLogger();
@@ -57,6 +58,18 @@ void main() {
 
       expect(result, equals(ExitCode.usage.code));
       verify(() => logger.err('undefined-arg is not a defined flag')).called(1);
+    });
+
+    test('changes the version and keeps build info', () async {
+      const error =
+          '''You cannot change to new version and keep old prelease and build info''';
+
+      final result = await commandRunner.run(
+        ['change', '--set-version=8.8.8', '--keep-build', '--set-path=$path'],
+      );
+
+      expect(result, equals(ExitCode.usage.code));
+      verify(() => logger.err(error)).called(1);
     });
   });
 
@@ -157,6 +170,34 @@ void main() {
 
       final current = await readFileNode('documentation');
       await resetFile(node: 'documentation', remove: true);
+
+      expect(result, equals(ExitCode.success.code));
+      expect(current, expectedChange);
+    });
+
+    test('changes the version using set-version', () async {
+      final result = await commandRunner.run(
+        ['change', setVersionArg, '--set-path=$path'],
+      );
+
+      const expectedChange = '8.8.8+8';
+
+      final current = await readFileNode('version');
+      await resetFile();
+
+      expect(result, equals(ExitCode.success.code));
+      expect(current, expectedChange);
+    });
+
+    test('changes the version and removes build & prelease info', () async {
+      final result = await commandRunner.run(
+        ['change', '--set-version=8.8.8', '--set-path=$path'],
+      );
+
+      const expectedChange = '8.8.8';
+
+      final current = await readFileNode('version');
+      await resetFile();
 
       expect(result, equals(ExitCode.success.code));
       expect(current, expectedChange);

--- a/test/src/commands/change_command_test.dart
+++ b/test/src/commands/change_command_test.dart
@@ -44,13 +44,13 @@ void main() {
   });
 
   group('throws error', () {
-    test('command must have arguments error', () async {
-      final args = ['change'];
-      final result = await commandRunner.run(args);
+    // test('command must have arguments error', () async {
+    //   final args = ['change'];
+    //   final result = await commandRunner.run(args);
 
-      expect(result, equals(ExitCode.usage.code));
-      verify(() => logger.err('No arguments found')).called(1);
-    });
+    //   expect(result, equals(ExitCode.usage.code));
+    //   verify(() => logger.err('No arguments found')).called(1);
+    // });
 
     test('invalid arguments passed to command', () async {
       final args = ['change', 'undefined-arg'];
@@ -177,7 +177,7 @@ void main() {
 
     test('changes the version using set-version', () async {
       final result = await commandRunner.run(
-        ['change', setVersionArg, '--set-path=$path'],
+        ['change', setVersionArg, '--keep-build', '--set-path=$path'],
       );
 
       const expectedChange = '8.8.8+8';

--- a/test/src/commands/change_command_test.dart
+++ b/test/src/commands/change_command_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     test('changes the version and keeps build info', () async {
       const error =
-          '''You cannot change to new version and keep old prelease and build info''';
+          '''You cannot change to new version and keep old prerelease and build info''';
 
       final result = await commandRunner.run(
         ['change', '--set-version=8.8.8', '--keep-build', '--set-path=$path'],
@@ -109,6 +109,17 @@ void main() {
       final result = await commandRunner.run(
         ['change', versionArg, '--with-path'],
       );
+
+      verify(
+        () => logger.warn(
+          """Consider using 'set-version'. 'yaml-version' will be deprecated soon""",
+        ),
+      ).called(1);
+      verify(
+        () => logger.warn(
+          "'set-version' will overwrite 'yaml-version' if both are used",
+        ),
+      ).called(1);
 
       final expectedChange = versionArg.split('=').last;
 
@@ -189,7 +200,7 @@ void main() {
       expect(current, expectedChange);
     });
 
-    test('changes the version and removes build & prelease info', () async {
+    test('changes the version and removes build & prerelease info', () async {
       final result = await commandRunner.run(
         ['change', '--set-version=8.8.8', '--set-path=$path'],
       );

--- a/test/src/commands/modify_command_test.dart
+++ b/test/src/commands/modify_command_test.dart
@@ -211,11 +211,11 @@ void main() {
     );
 
     test(
-      'sets version & build before bumping major version & build-number',
+      'sets version only before bumping major version then sets build-number',
       () async {
         const setVersion = '11.12.13';
         const setBuild = '13';
-        const updatedVersion = '12.0.0+14';
+        const updatedVersion = '12.0.0+13';
 
         final args = [
           'modify',

--- a/test/src/commands/modify_command_test.dart
+++ b/test/src/commands/modify_command_test.dart
@@ -256,7 +256,7 @@ void main() {
       expect(bumpedVersion, updatedVersion);
     });
 
-    test('sets prelease and removes build', () async {
+    test('sets prerelease and removes build', () async {
       const setPre = 'alpha';
       const updatedVersion = '10.10.10-alpha';
 
@@ -276,7 +276,7 @@ void main() {
       expect(bumpedVersion, updatedVersion);
     });
 
-    test('sets prelease and bumps & keeps build', () async {
+    test('sets prerelease and bumps & keeps build', () async {
       const setPre = 'alpha';
       const updatedVersion = '10.10.10-alpha+11';
 

--- a/test/src/commands/modify_command_test.dart
+++ b/test/src/commands/modify_command_test.dart
@@ -44,13 +44,13 @@ void main() {
   });
 
   group('throws error', () {
-    test('command must have arguments error', () async {
-      final args = ['modify'];
-      final result = await commandRunner.run(args);
+    // test('command must have arguments error', () async {
+    //   final args = ['modify'];
+    //   final result = await commandRunner.run(args);
 
-      expect(result, equals(ExitCode.usage.code));
-      verify(() => logger.err('No arguments found')).called(1);
-    });
+    //   expect(result, equals(ExitCode.usage.code));
+    //   verify(() => logger.err('No arguments found')).called(1);
+    // });
 
     test('invalid arguments passed to command', () async {
       final args = ['modify', 'undefined-arg'];
@@ -163,6 +163,139 @@ void main() {
         expect(bumpedVersion, version);
       },
     );
+  });
+
+  group('modifies with setters', () {
+    test('sets version before bumping major version', () async {
+      const setVersion = '11.12.13';
+      const updatedVersion = '12.0.0';
+
+      final args = [
+        'modify',
+        '-b',
+        '--major',
+        '--set-version=$setVersion',
+        'set-path=$path'
+      ];
+
+      final result = await commandRunner.run(args);
+
+      final bumpedVersion = await readFileNode('version');
+
+      expect(result, equals(ExitCode.success.code));
+      expect(bumpedVersion, updatedVersion);
+    });
+
+    test(
+      'sets version and keeps build before bumping major version',
+      () async {
+        const setVersion = '11.12.13';
+        const updatedVersion = '12.0.0+10';
+
+        final args = [
+          'modify',
+          '-b',
+          '--major',
+          '--set-version=$setVersion',
+          '--keep-build',
+          'set-path=$path'
+        ];
+
+        final result = await commandRunner.run(args);
+
+        final bumpedVersion = await readFileNode('version');
+
+        expect(result, equals(ExitCode.success.code));
+        expect(bumpedVersion, updatedVersion);
+      },
+    );
+
+    test(
+      'sets version & build before bumping major version & build-number',
+      () async {
+        const setVersion = '11.12.13';
+        const setBuild = '13';
+        const updatedVersion = '12.0.0+14';
+
+        final args = [
+          'modify',
+          '-b',
+          '--major',
+          '--build-number',
+          '--set-version=$setVersion',
+          '--set-build=$setBuild',
+          'set-path=$path'
+        ];
+
+        final result = await commandRunner.run(args);
+
+        final bumpedVersion = await readFileNode('version');
+
+        expect(result, equals(ExitCode.success.code));
+        expect(bumpedVersion, updatedVersion);
+      },
+    );
+
+    test('sets build after bumping old build-number', () async {
+      const setBuild = '13';
+      const updatedVersion = '10.10.10+13';
+
+      final args = [
+        'modify',
+        '-b',
+        '--build-number',
+        '--set-build=$setBuild',
+        'set-path=$path'
+      ];
+
+      final result = await commandRunner.run(args);
+
+      final bumpedVersion = await readFileNode('version');
+
+      expect(result, equals(ExitCode.success.code));
+      expect(bumpedVersion, updatedVersion);
+    });
+
+    test('sets prelease and removes build', () async {
+      const setPre = 'alpha';
+      const updatedVersion = '10.10.10-alpha';
+
+      final args = [
+        'modify',
+        '-b',
+        '--build-number',
+        '--set-prerelease=$setPre',
+        'set-path=$path'
+      ];
+
+      final result = await commandRunner.run(args);
+
+      final bumpedVersion = await readFileNode('version');
+
+      expect(result, equals(ExitCode.success.code));
+      expect(bumpedVersion, updatedVersion);
+    });
+
+    test('sets prelease and bumps & keeps build', () async {
+      const setPre = 'alpha';
+      const updatedVersion = '10.10.10-alpha+11';
+
+      final args = [
+        'modify',
+        '-b',
+        '--build-number',
+        '--set-prerelease=$setPre',
+        '--keep-build',
+        'set-path=$path'
+      ];
+
+      final result = await commandRunner.run(args);
+
+      final bumpedVersion = await readFileNode('version');
+
+      expect(result, equals(ExitCode.success.code));
+      expect(bumpedVersion, updatedVersion);
+    });
   });
 
   tearDown(() async => resetFile());

--- a/test/src/mixins/normalize_args_mixin_test.dart
+++ b/test/src/mixins/normalize_args_mixin_test.dart
@@ -52,6 +52,20 @@ void main() {
       expect(checkedSetters.keepPre, true);
       expect(checkedSetters.preset, true);
     });
+
+    test('returns preset as false and preset-version as true', () {
+      final args = <String>[
+        'myArg',
+        'set-version=1.0.0',
+      ];
+
+      final checkedSetters = normalizer.checkForSetters(args);
+
+      expect(listEquality.equals(checkedSetters.args, ['myArg']), true);
+      expect(checkedSetters.version, '1.0.0');
+      expect(checkedSetters.preset, false);
+      expect(checkedSetters.presetOnlyVersion, true);
+    });
   });
 
   group('preps modify commands args', () {

--- a/test/src/mixins/normalize_args_mixin_test.dart
+++ b/test/src/mixins/normalize_args_mixin_test.dart
@@ -22,33 +22,11 @@ void main() {
       final normalizedFlags = normalizer.normalizeArgs(flags);
 
       final wasNormalized = listEquality.equals(
-        normalizedFlags.args,
+        normalizedFlags,
         sanitizedFlags,
       );
 
       expect(wasNormalized, true);
-      expect(normalizedFlags.hasPath, false);
-      expect(normalizedFlags.setPath, isNull);
-    });
-
-    test("removes the '--' & '-' appended to flags with set path", () {
-      final flags = <String>[
-        '--double-fake-flag',
-        '-single-fake-flag',
-        '--set-path=myPath'
-      ];
-      final sanitizedFlags = <String>['double-fake-flag', 'single-fake-flag'];
-
-      final normalizedFlags = normalizer.normalizeArgs(flags);
-
-      final wasNormalized = listEquality.equals(
-        normalizedFlags.args,
-        sanitizedFlags,
-      );
-
-      expect(wasNormalized, true);
-      expect(normalizedFlags.hasPath, true);
-      expect(normalizedFlags.setPath, 'myPath');
     });
   });
 

--- a/test/src/mixins/normalize_args_mixin_test.dart
+++ b/test/src/mixins/normalize_args_mixin_test.dart
@@ -28,6 +28,30 @@ void main() {
 
       expect(wasNormalized, true);
     });
+
+    test('gets all setter options in args', () {
+      final args = <String>[
+        'myArg',
+        'set-path=path',
+        'set-build=build',
+        'set-prerelease=prerelease',
+        'set-version=1.0.0',
+        'keep-pre',
+        'keep-build',
+        'preset',
+      ];
+
+      final checkedSetters = normalizer.checkForSetters(args);
+
+      expect(listEquality.equals(checkedSetters.args, ['myArg']), true);
+      expect(checkedSetters.path, 'path');
+      expect(checkedSetters.build, 'build');
+      expect(checkedSetters.prerelease, 'prerelease');
+      expect(checkedSetters.version, '1.0.0');
+      expect(checkedSetters.keepBuild, true);
+      expect(checkedSetters.keepPre, true);
+      expect(checkedSetters.preset, true);
+    });
   });
 
   group('preps modify commands args', () {

--- a/test/src/mixins/validate_args_mixin_test.dart
+++ b/test/src/mixins/validate_args_mixin_test.dart
@@ -17,20 +17,20 @@ void main() {
   });
 
   group('basic errors with no set path', () {
-    test('returns error when no args are passed', () async {
-      const baseError = 'Missing arguments';
-      const verboseError = 'No arguments found';
+    // test('returns error when no args are passed', () async {
+    //   const baseError = 'Missing arguments';
+    //   const verboseError = 'No arguments found';
 
-      final validated = await validator.validateArgs(
-        [],
-        userSetPath: false,
-        logger: logger,
-      );
+    //   final validated = await validator.validateArgs(
+    //     [],
+    //     userSetPath: false,
+    //     logger: logger,
+    //   );
 
-      expect(validated.invalidReason, isNotNull);
-      expect(validated.invalidReason!.key, baseError);
-      expect(validated.invalidReason!.value, verboseError);
-    });
+    //   expect(validated.invalidReason, isNotNull);
+    //   expect(validated.invalidReason!.key, baseError);
+    //   expect(validated.invalidReason!.value, verboseError);
+    // });
 
     test('returns error when undefined flags are passed', () async {
       const undefinedArg = ['undefined-arg'];


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR:
* adds new `preset` flag to `modify` command
* adds new `set-version` option to both commands
* adds `keep-pre` & `keep-build` flags to `modify` command
* adds `set-build` & `set-prerelease` options to `modify` command
* adds new tests & updates old tests

It also adds preset ability discussed in #14 


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
